### PR TITLE
Support empty categories for remote diff state

### DIFF
--- a/api/state.go
+++ b/api/state.go
@@ -7,9 +7,16 @@ import (
 )
 
 // GenerateDiffState generates a diff.State struct from a list of feeds.
-func GenerateDiffState(feeds []*miniflux.Feed) (*diff.State, error) {
+func GenerateDiffState(
+	feeds []*miniflux.Feed, categories []*miniflux.Category,
+) (*diff.State, error) {
 	state := diff.State{
 		FeedURLsByCategoryTitle: map[string][]string{},
+	}
+
+	// Initialise empty slices for each category.
+	for _, category := range categories {
+		state.FeedURLsByCategoryTitle[category.Title] = []string{}
 	}
 
 	// Populate state with values, and create category set.

--- a/cmd/dump.go
+++ b/cmd/dump.go
@@ -17,12 +17,12 @@ import (
 func dump(ctx context.Context, flags *config.DumpFlags, client *miniflux.Client) error {
 	log.Info(ctx, "exporting data from miniflux")
 
-	feeds, _, err := api.FetchData(ctx, client)
+	feeds, categories, err := api.FetchData(ctx, client)
 	if err != nil {
 		return errors.Wrap(err, "fetching data")
 	}
 
-	remoteState, err := api.GenerateDiffState(feeds)
+	remoteState, err := api.GenerateDiffState(feeds, categories)
 	if err != nil {
 		return errors.Wrap(err, "generating remote state")
 	}

--- a/cmd/sync.go
+++ b/cmd/sync.go
@@ -43,7 +43,7 @@ func sync( //nolint:cyclop,funlen
 		return errors.Wrap(err, "fetching data")
 	}
 
-	remoteState, err := api.GenerateDiffState(feeds)
+	remoteState, err := api.GenerateDiffState(feeds, categories)
 	if err != nil {
 		return errors.Wrap(err, "generating remote state")
 	}


### PR DESCRIPTION
Closes #5.

Categories in the remote diff state were being created from those in feeds, so empty categories were ignored.